### PR TITLE
Typos in code

### DIFF
--- a/sbtn-SoN-water.qmd
+++ b/sbtn-SoN-water.qmd
@@ -252,9 +252,9 @@ nox_n <- nox_n |>
     nox_raw = median,
     nox_n = case_when(
       median <= 0.4 ~ 1,
-      between(median, 0.4, 0.8) ~ 2,
-      between(median, 0.8, 1.2) ~ 3,
-      between(median, 1.2, 1.6) ~ 4,
+      median > 0.4 & median <= 0.8 ~ 2,
+      median > 0.8 & median <= 1.2 ~ 3,
+      median > 1.2 & median <= 1.6 ~ 4,
       median > 1.6 ~ 5
     ),
     nox_label = case_when(
@@ -296,15 +296,16 @@ pgp_n <- tnc_n |>
     limiting = if_else(ratio_n_p < 7, "N-limited", "P-limited"),
     pgp_n = case_when(
       limiting == "N-limited" & tnc_raw <= 0.4 ~ 1,
-      limiting == "N-limited" & between(tnc_raw, 0.4, 0.8) ~ 2,
-      limiting == "N-limited" & between(tnc_raw, 0.8, 1.2) ~ 3,
-      limiting == "N-limited" & between(tnc_raw, 1.2, 1.6) ~ 4,
+      limiting == "N-limited" & tnc_raw > 0.4 & tnc_raw <= 0.8 ~ 2,
+      limiting == "N-limited" & tnc_raw > 0.8 & tnc_raw <= 1.2 ~ 3,
+      limiting == "N-limited" & tnc_raw > 1.2 & tnc_raw <= 1.6 ~ 4,
       limiting == "N-limited" & tnc_raw > 1.6 ~ 5,
       
       limiting == "P-limited" & tpc_raw <= 0.023 ~ 1,
-      limiting == "P-limited" & between(tpc_raw, 0.023, 0.046) ~ 2,
-      limiting == "P-limited" & between(tpc_raw, 0.046, 0.100) ~ 3,
-      limiting == "P-limited" & between(tpc_raw, 0.100, 0.150) ~ 4,
+
+      limiting == "P-limited" & tpc_raw > 0.023 & tpc_raw <= 0.046 ~ 2,
+      limiting == "P-limited" & tpc_raw > 0.046 & tpc_raw <= 0.100  ~ 3,
+      limiting == "P-limited" & tpc_raw > 0.100 & tpc_raw <= 0.150 ~ 4,
       limiting == "P-limited" & tpc_raw > 0.150 ~ 5
     ),
     pgp_label = case_when(

--- a/sbtn-SoN-water.qmd
+++ b/sbtn-SoN-water.qmd
@@ -214,7 +214,7 @@ cep_n <- cep |>
     cep_raw = na_if(cep_raw, -9999),
     cep_raw = na_if(cep_raw, 9999),
     cep_n = case_when(
-      cep_label == "Low (<-5)" ~ 1,
+      cep_label == "Low (<= -5)" ~ 1,
       cep_label == "Low - Medium (-5 to 0)" ~ 2,
       cep_label == "Medium - High (0 to 1)" ~ 3,
       cep_label == "High (1 to 5)" ~ 4,


### PR DESCRIPTION
To ensure that code and documentation are aligned.
- For cep, risk score 1 should be labelled <= -5 rather than < -5
- For nox and pgp, remove use of `between()`. `between()` is equivalent to left <= x <= right, but these indicators should use left < x <= right. **Note:** I checked that this has no affect on the outcome, but have updated it here to ensure there is no confusion between documentation and code.